### PR TITLE
Bugfix for multiple definitions of standard io streams

### DIFF
--- a/include/cest/iostream.hpp
+++ b/include/cest/iostream.hpp
@@ -8,16 +8,16 @@
 namespace cest {
 
 namespace impl {
-basic_stringbuf cout(string("cout"));
-basic_stringbuf cerr(string("cerr"));
-basic_stringbuf clog(string("clog"));
-basic_stringbuf cin(string("cin"));
+inline basic_stringbuf cout(string("cout"));
+inline basic_stringbuf cerr(string("cerr"));
+inline basic_stringbuf clog(string("clog"));
+inline basic_stringbuf cin(string("cin"));
 } // namespace impl
 
-ostream cout(&impl::cout);
-ostream cerr(&impl::cerr);
-ostream clog(&impl::clog);
-istream cin(&impl::cin);
+inline ostream cout(&impl::cout);
+inline ostream cerr(&impl::cerr);
+inline ostream clog(&impl::clog);
+inline istream cin(&impl::cin);
 
 using iostream = basic_iostream<char>;
 using wiostream = basic_iostream<wchar_t>;


### PR DESCRIPTION
Added inline specifiers to avoid multiple definitions of cout, cerr, clog, and cin when linking two C++ objects that both include `cest/iostream.hpp`